### PR TITLE
Update macos.nim so that it compiles

### DIFF
--- a/src/libclip/clipboard/macos.nim
+++ b/src/libclip/clipboard/macos.nim
@@ -1,7 +1,7 @@
 import osproc
 import streams
 
-import libclip/process
+import libclip/utils/process
 
 proc setClipboardText*(text: string): bool =
   let p = startProcess("pbcopy", options = {poUsePath, poStderrToStdout})


### PR DESCRIPTION
This tiny change made it work perfectly fine on my OSX Seqoia: Version 15.6 (24G84)